### PR TITLE
removed copyright and year

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -227,7 +227,7 @@
                 <p>The hardware and bandwidth for this mirror is donated by <a href="https://www.adfinis-sygroup.ch">Adfinis SyGroup AG</a> to the open-source and free software community.</p>
               </div>
               <div>
-                <small>&copy; 2019 Adfinis SyGroup AG</small>
+                <small>Adfinis SyGroup AG</small>
               </div>
               <div>
                 <small>Provided by: </small>
@@ -248,7 +248,7 @@
         <pre><code>
 http://pkg.adfinis-sygroup.ch/alpine/v3.7/main
 https://pkg.adfinis-sygroup.ch/alpine/v3.7/main
-        </code></pre><br> 
+        </code></pre><br>
 
           <h3>Additional information</h3>
           <p>You can find further information about our mirror on the following site:


### PR DESCRIPTION
so we don't have to change the year on the site manually every year :)

+ the copyright symbol in switzerland has no affection.
further information here:
https://www.beobachter.ch/rechtslexikon/copyright

cheers
luk