### PR TITLE
fix logo and footer

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -224,14 +224,7 @@
 
             <footer class="page-content-footer">
               <div class="footer-maxwidth">
-                <p>The hardware and bandwidth for this mirror is donated by <a href="https://www.adfinis.com">Adfinis AG</a> to the open-source and free software community.</p>
-              </div>
-              <div>
-                <small>Adfinis AG</small>
-              </div>
-              <div>
-                <small>Provided by: </small>
-                <a href="https://www.adfinis.com/" alt="Adfinis AG"><img class="footer-logo" src="icons/adfinis.png" width="100px" height="20px" align="top"></a>
+                <p>The hardware and bandwidth for this mirror is donated by <a href="https://adfinis.com"><img class="footer-logo" src="icons/adfinis.png" height="20px" align="top"></a> to the open-source and free software community.</p>
               </div>
             </footer>
           </section>


### PR DESCRIPTION
* logo size wasn't right for our new logo.
* remove ugly provided by and broken copyright notice which is
unnecessary

Signed-off-by: Philipp Marmet (Adfinis AG) <philipp.marmet@adfinis.com>